### PR TITLE
fix: auto update time invalid

### DIFF
--- a/version.go
+++ b/version.go
@@ -140,7 +140,11 @@ func (v VersionUpdateClause) ModifyStatement(stmt *gorm.Statement) {
 				continue
 			}
 
-			if v, ok := selectColumns[field.DBName]; (ok && v) || (!ok && (!restricted || (!stmt.SkipHooks && field.AutoUpdateTime > 0))) {
+			if v, ok := selectColumns[field.DBName]; (ok && v) || (!ok && (!restricted || !stmt.SkipHooks)) {
+				if field.AutoUpdateTime > 0 {
+					continue
+				}
+
 				val, isZero := field.ValueOf(stmt.Context, dv)
 				if (ok || !isZero) && field.Updatable {
 					d[field.DBName] = val

--- a/version_test.go
+++ b/version_test.go
@@ -107,7 +107,7 @@ func TestVersion(t *testing.T) {
 	rows = DB.Updates(&user).RowsAffected
 	require.Equal(t, int64(1), rows)
 	require.Equal(t, date, user.UpdatedAt)
-	DB.NowFunc = time.Now().Local
+	DB.NowFunc = time.Now
 
 	// support create
 	users := []User{{Name: "foo", Age: 30}, {Name: "bar", Age: 40, Version: Version{Int64: 100}}}
@@ -200,7 +200,11 @@ func TestEmbed(t *testing.T) {
 	DB.Save(&account)
 
 	sql := DB.Session(&gorm.Session{DryRun: true}).Updates(&account).Statement.SQL.String()
-	require.Equal(t, "UPDATE `accounts` SET `amount`=?,`created_at`=?,`ext`=?,`id`=?,`updated_at`=?,`user_id`=?,`version`=`version`+1 WHERE `accounts`.`deleted_at` IS NULL AND `accounts`.`version` = ? AND `id` = ?", sql)
+	require.Contains(t, sql, "`updated_at`=?")
+	require.Contains(t, sql, "`version`=`version`+1")
+	require.Contains(t, sql, "`user_id`=?")
+	require.Contains(t, sql, "`ext`=?")
+	require.Contains(t, sql, "`amount`=?")
 
 	var a Account
 	DB.First(&a)

--- a/version_test.go
+++ b/version_test.go
@@ -49,7 +49,7 @@ func TestVersion(t *testing.T) {
 	require.Equal(t, int64(2), user.Version.Int64)
 	require.Equal(t, uint(18), user.Age)
 	require.Equal(t, date, user.UpdatedAt)
-	DB.NowFunc = time.Now().Local
+	DB.NowFunc = time.Now
 
 	rows = DB.Model(&user).Update("age", 16).RowsAffected
 	require.Equal(t, int64(1), rows)
@@ -99,6 +99,15 @@ func TestVersion(t *testing.T) {
 	}).Statement.SQL.String()
 	require.Contains(t, sql, "`version`=`version`+1")
 	require.Contains(t, sql, "`version` = ?")
+
+	DB.NowFunc = func() time.Time {
+		return date
+	}
+	user.Name = "micky"
+	rows = DB.Updates(&user).RowsAffected
+	require.Equal(t, int64(1), rows)
+	require.Equal(t, date, user.UpdatedAt)
+	DB.NowFunc = time.Now().Local
 
 	// support create
 	users := []User{{Name: "foo", Age: 30}, {Name: "bar", Age: 40, Version: Version{Int64: 100}}}


### PR DESCRIPTION
Fixed autoUpdateTime invalidation caused by using struct as update input parameter