### PR TITLE
fix: Avoid invalid SQL for updating structs with relation pointers

### DIFF
--- a/version.go
+++ b/version.go
@@ -141,6 +141,9 @@ func (v VersionUpdateClause) ModifyStatement(stmt *gorm.Statement) {
 			if field.DBName == v.Field.DBName {
 				continue
 			}
+			if field.DBName == "" {
+				continue
+			}
 
 			if v, ok := selectColumns[field.DBName]; (ok && v) || (!ok && (!restricted || !stmt.SkipHooks)) {
 				if field.AutoUpdateTime > 0 {

--- a/version_test.go
+++ b/version_test.go
@@ -198,12 +198,14 @@ func TestEmbed(t *testing.T) {
 
 	account := Account{
 		UserID: 1,
+		User:   &user,
 		Amount: 1000,
 		Ext:    Ext{CreditCard: []string{"123456", "456123"}},
 	}
 	_ = DB.Migrator().DropTable(&Account{})
 	_ = DB.AutoMigrate(&Account{})
-	DB.Save(&account)
+	require.Nil(t, DB.Save(&account).Error)
+	require.Nil(t, DB.Save(&account).Error)
 
 	sql := DB.Session(&gorm.Session{DryRun: true}).Updates(&account).Statement.SQL.String()
 	require.Contains(t, sql, "`updated_at`=?")
@@ -232,8 +234,8 @@ func TestEmbed(t *testing.T) {
 	var a1 Account
 	require.Nil(t, DB.First(&a1).Error)
 	require.Equal(t, a.Amount, a1.Amount)
-	require.Equal(t, int64(2), a.Version.Int64)
-	require.Equal(t, int64(3), a1.Version.Int64)
+	require.Equal(t, int64(3), a.Version.Int64)
+	require.Equal(t, int64(4), a1.Version.Int64)
 }
 
 // use gorm.io/gorm/tests docker compose file


### PR DESCRIPTION
### What did this pull request do?

fix: Avoid invalid SQL for updating structs with relation pointers

Previously update attempts on structs which contained pointers to other models would fail to build SQL, attempting to cast the pointer relation struct to SQL. This PR fixes that issue by not attempting to build SQL for fields that don't have a DB field name.

To give more specifics about the issue, the test case failed with the following error until the fix was introduced:

```
$ go test ./... -run TestEmbed 
=== RUN   TestEmbed

optimisticlock/version_test.go:208 sql: converting argument $1 type: unsupported type optimisticlock.User, a struct
[0.300ms] [rows:0] UPDATE `accounts` SET ``="{{1 2023-04-27 00:34:08.533310929 -0700 PDT 2023-04-27 00:34:08.533310929 -0700 PDT {0001-01-01 00:00:00 +0000 UTC false}} bob 20 {1 true}}",`amount`=1000,`created_at`="2023-04-27 00:34:08.534",`deleted_at`=NULL,`ext`="{\"CreditCard\":[\"123456\",\"456123\"]}",`id`=1,`user_id`=1,`version`=`version`+1,`updated_at`="2023-04-27 00:34:08.534" WHERE `accounts`.`deleted_at` IS NULL AND `accounts`.`version` = 1 AND `id` = 1
    version_test.go:208:
                Error Trace:    version_test.go:208
                Error:          Expected nil, but got: &errors.errorString{s:"sql: converting argument $1 type: unsupported type optimisticlock.User, a struct"}
                Test:           TestEmbed
--- FAIL: TestEmbed (0.00s)
FAIL
FAIL    gorm.io/plugin/optimisticlock   0.008s
FAIL
```

### User Case Description

I'm hoping to use optimisticlock in a project where structs are preloaded with many relations, modified, and then saved.
